### PR TITLE
Use Symbols for Row properties, Object.create() without a PropertyMap instead of constructor calls

### DIFF
--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -38,8 +38,7 @@ export type IntBitWidth = 8 | 16 | 32 | 64;
 export type IsSigned = { 'true': true; 'false': false };
 /** @ignore */
 export type RowLike<T extends { [key: string]: DataType; }> =
-      { readonly length: number }
-    & ( Iterable<T[keyof T]['TValue']> )
+      ( Iterable<T[keyof T]['TValue']> )
     & { [P in keyof T]: T[P]['TValue'] }
     & { get<K extends keyof T>(key: K): T[K]['TValue']; }
     ;

--- a/js/src/util/vector.ts
+++ b/js/src/util/vector.ts
@@ -16,7 +16,7 @@
 // under the License.
 
 import { Vector } from '../vector';
-import { Row } from '../vector/row';
+import { Row, kLength } from '../vector/row';
 import { compareArrayLike } from '../util/buffer';
 
 /** @ignore */
@@ -75,75 +75,105 @@ export function createElementComparator(search: any) {
     }
     // Compare Array-likes
     if (Array.isArray(search)) {
-        const n = (search as any).length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any)[i]);
-        }
-        return (value: any) => {
-            if (!value || value.length !== n) { return false; }
-            // Handle the case where the search element is an Array, but the
-            // values are Rows or Vectors, e.g. list.indexOf(['foo', 'bar'])
-            if ((value instanceof Row) || (value instanceof Vector)) {
-                for (let i = -1, n = value.length; ++i < n;) {
-                    if (!(fns[i]((value as any).get(i)))) { return false; }
-                }
-                return true;
-            }
-            for (let i = -1, n = value.length; ++i < n;) {
-                if (!(fns[i](value[i]))) { return false; }
-            }
-            return true;
-        };
-    }
-    // Compare Vectors
-    if (search instanceof Vector) {
-        const n = search.length;
-        const C = search.constructor as any;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any).get(i));
-        }
-        return (value: any) => {
-            if (!(value instanceof C)) { return false; }
-            if (!(value.length === n)) { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value.get(i)))) { return false; }
-            }
-            return true;
-        };
+        return createArrayLikeComparator(search);
     }
     // Compare Rows
     if (search instanceof Row) {
-        const n = search.length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any).get(i));
-        }
-        return (value: any) => {
-            if (!(value.length === n)) { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value.get(i)))) { return false; }
-            }
-            return true;
-        };
+        return createRowComparator(search);
+    }
+    // Compare Vectors
+    if (search instanceof Vector) {
+        return createVectorComparator(search);
     }
     // Compare non-empty Objects
     const keys = Object.keys(search);
     if (keys.length > 0) {
-        const n = keys.length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator(search[keys[i]]);
-        }
-        return (value: any) => {
-            if (!value || typeof value !== 'object') { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value[keys[i]]))) { return false; }
-            }
-            return true;
-        };
+        return createObjectKeysComparator(search, keys);
     }
     // No valid comparator
     return () => false;
+}
+
+/** @ignore */
+function createArrayLikeComparator(search: ArrayLike<any>) {
+    const n = search.length;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator((search as any)[i]);
+    }
+    return (value: any) => {
+        if (!value) { return false; }
+        // Handle the case where the search element is an Array, but the
+        // values are Rows or Vectors, e.g. list.indexOf(['foo', 'bar'])
+        if (value instanceof Row) {
+            if (value[kLength] !== n) { return false; }
+            for (let i = -1; ++i < n;) {
+                if (!(fns[i](value.get(i)))) { return false; }
+            }
+            return true;
+        }
+        if (value.length !== n) { return false; }
+        if (value instanceof Vector) {
+            for (let i = -1; ++i < n;) {
+                if (!(fns[i](value.get(i)))) { return false; }
+            }
+            return true;
+        }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value[i]))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createRowComparator(search: Row<any>) {
+    const n = search[kLength];
+    const C = search.constructor as any;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator(search.get(i));
+    }
+    return (value: any) => {
+        if (!(value instanceof C)) { return false; }
+        if (!(value[kLength] === n)) { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value.get(i)))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createVectorComparator(search: Vector<any>) {
+    const n = search.length;
+    const C = search.constructor as any;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator((search as any).get(i));
+    }
+    return (value: any) => {
+        if (!(value instanceof C)) { return false; }
+        if (!(value.length === n)) { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value.get(i)))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createObjectKeysComparator(search: any, keys: string[]) {
+    const n = keys.length;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator(search[keys[i]]);
+    }
+    return (value: any) => {
+        if (!value || typeof value !== 'object') { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value[keys[i]]))) { return false; }
+        }
+        return true;
+    };
 }

--- a/js/src/vector/map.ts
+++ b/js/src/vector/map.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { RowProxyGenerator } from './row';
+import { Row } from './row';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
 import { DataType, Map_, Struct } from '../type';
@@ -25,8 +25,8 @@ export class MapVector<T extends { [key: string]: DataType } = any> extends Base
         return Vector.new(this.data.clone(new Struct<T>(this.type.children)));
     }
     // @ts-ignore
-    private _rowProxy: RowProxyGenerator<T>;
-    public get rowProxy(): RowProxyGenerator<T> {
-        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], true));
+    private _rowProxy: Row<T>;
+    public get rowProxy(): Row<T> {
+        return this._rowProxy || (this._rowProxy = Row.new<T>(this, this.type.children || [], true));
     }
 }

--- a/js/src/vector/struct.ts
+++ b/js/src/vector/struct.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { RowProxyGenerator } from './row';
+import { Row } from './row';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
 import { DataType, Map_, Struct } from '../type';
@@ -25,8 +25,8 @@ export class StructVector<T extends { [key: string]: DataType } = any> extends B
         return Vector.new(this.data.clone(new Map_<T>(this.type.children, keysSorted)));
     }
     // @ts-ignore
-    private _rowProxy: RowProxyGenerator<T>;
-    public get rowProxy(): RowProxyGenerator<T> {
-        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], false));
+    private _rowProxy: Row<T>;
+    public get rowProxy(): Row<T> {
+        return this._rowProxy || (this._rowProxy = Row.new<T>(this, this.type.children || [], false));
     }
 }

--- a/js/src/visitor/get.ts
+++ b/js/src/visitor/get.ts
@@ -211,7 +211,7 @@ const getNested = <
     S extends { [key: string]: DataType },
     V extends Vector<Map_<S>> | Vector<Struct<S>>
 >(vector: V, index: number): V['TValue'] => {
-    return vector.rowProxy.bind(vector, index);
+    return vector.rowProxy.bind(index);
 };
 
 /* istanbul ignore next */


### PR DESCRIPTION
Current version of proxy-bench:
```
Table Iterate "tracks":
length: 1000000
 x 6.88 ops/sec ±0.82% (21 runs sampled)
   avg: 145.4ms
   872.4% of a frame @ 60FPS 
```

This PR:
```
Table Iterate "tracks":
length: 1000000
 x 8.36 ops/sec ±1.02% (25 runs sampled)
   avg: 119.58ms
   717.48% of a frame @ 60FPS 
```